### PR TITLE
Add support for twitter hashtag

### DIFF
--- a/cat/templates/event.html
+++ b/cat/templates/event.html
@@ -32,6 +32,12 @@
 <div>Twitter: <a href="https://twitter.com/{{ event['twitter'] }}">@{{ event['twitter'] }}</a></div>
 {% endif %}
 
+{% if event['hashtag'] %}
+<div>Hashtag: <a href="https://twitter.com/hashtag/{{ event['hashtag'] }}">#{{ event['hashtag'] }}</a></div>
+{% elif event['twitter'] %}
+<div>Hashtag: <a href="https://twitter.com/hashtag/{{ event['twitter'] }}">#{{ event['twitter'] }}</a></div>
+{% endif %}
+
 {% if event['facebook'] %}
 <div>Facebook: <a href="{{ event['facebook'] }}">{{ event['facebook'] }}</a></div>
 {% endif %}

--- a/data/events/oscal-2017.txt
+++ b/data/events/oscal-2017.txt
@@ -11,7 +11,7 @@ topics:          opensource
 languages:       English
 code_of_conduct: http://oscal.openlabs.cc/code-of-conduct/
 twitter:         OSCALconf
-hashtag:         #OSCAL2017
+hashtag:         OSCAL2017
 facebook:        
 accessibility:   
 diversitytickets:

--- a/data/skeleton-event.txt
+++ b/data/skeleton-event.txt
@@ -9,7 +9,8 @@ country:
 topics:          
 languages:       English
 code_of_conduct: 
-twitter:         
+twitter:
+hashtag:
 facebook:        
 accessibility:   
 diversitytickets:

--- a/docs/CONFERENCES.md
+++ b/docs/CONFERENCES.md
@@ -21,6 +21,7 @@ languages:          Portuguese, English
 code_of_conduct:    URL to Code of Conduct
 accessibility:      URL to document about accessibility
 twitter:            handle         (don't include the @)
+hashtag:            hashtag,if not specified the handle will be used (don't include the #)
 facebook:
 youtube:           Once the event is over, the YouTube playlist of its videos.
 


### PR DESCRIPTION
A new field for events is now supported :'hashtag'
It will create a link to Twitter with a search for this hashtag.
If the hashtag is not present, and the twitter account is available
then the account name will be used as the hashtag.