### PR TITLE
Fixing a (significant) typo and Description

### DIFF
--- a/data/videos/reversim-2016/coderetreat-what-why-and-how-erez-lotan.html
+++ b/data/videos/reversim-2016/coderetreat-what-why-and-how-erez-lotan.html
@@ -1,9 +1,6 @@
 <a href="http://coderetreat.org/">Coderetreat</a> is a day-long, intensive practice event, focusing on the fundamentals of software development and design.
 It is also a lot of fun.
 <p>
-We at <a href="https://www.kensho.com/#/">Kenshoo</a> are doing those periodically - hear why, and learn how you can start as well.
-The newcomer into this world is overwhelmed with information, patterns, tools and practices.
-Having delivered numerous such projects, I'll try to separate the wheat from the chaff.
-<p>
-This is a clear recipe for the key practices you should keep when building continuously delivered microservice.
+We at <a href="http://www.kenshoo.com/">Kenshoo</a> are doing those periodically - hear why, and learn how you can start as well.
+
 


### PR DESCRIPTION
Actually Kensho (single 'o') is a different company than Kenshoo ('oo') which is where we're having coderetreats :)

While at it, also fixed the description which contained text from 'Simple Battle Proven Microservices' - a different talk I gave at Reversim2016.