### PR TITLE
Add PNWPHP 2017

### DIFF
--- a/data/events/pnwphp-2017.txt
+++ b/data/events/pnwphp-2017.txt
@@ -1,0 +1,13 @@
+name:            Pacific Northwest PHP 2017
+url:             http://www.pnwphp.com/
+start_date:      2017-09-07
+end_date:        2017-09-09
+cfp_date:        2017-05-15
+city:            Seattle
+state:           Washington
+country:         USA
+topics:          PHP, web
+languages:       English
+twitter:         pnwphp
+facebook:        https://www.facebook.com/midwestconf
+description:     A 3-day event in the Pacific Northwest region of the United States for PHP and Web developers. Past conferences have included world renown speakers from the PHP community, about a wide range of topics — from APIs and CMS to unit testing and version control.


### PR DESCRIPTION
Unrelated, but do you keep copies of older occurrences of the same conference?  This one has been going strong since 2015.