### PR TITLE
Remove Facebook link from PNWPHP 2017

### DIFF
--- a/data/events/pnwphp-2017.txt
+++ b/data/events/pnwphp-2017.txt
@@ -9,5 +9,4 @@ country:         USA
 topics:          PHP, web
 languages:       English
 twitter:         pnwphp
-facebook:        https://www.facebook.com/midwestconf
 description:     A 3-day event in the Pacific Northwest region of the United States for PHP and Web developers. Past conferences have included world renown speakers from the PHP community, about a wide range of topics — from APIs and CMS to unit testing and version control.


### PR DESCRIPTION
I copied and pasted from another file (no points for guessing which one ;) ) and PNWPHP does not have a Facebook page