### PR TITLE
Removed that name must end with year of event

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -30,7 +30,7 @@ It must be all lowercase and needs to include some identifier of the year and so
         "country":              "Name of the country (from the list in data/countries.csv) if a country is missing from that list add that too!",
         "state":                "Relevant in US, Brasil, Australia, India, and UK"
     },
-    "name":         "The name might need to include the country/city and the year. Check similar events.  It should end with the year of the event. (e.g. 2016)",
+    "name":         "The name might need to include the country/city and the year. Check similar events.",
     "tags": [
                     "comma separated list of lower-case strings (in double quotes) taken from data/tags.json",
     ],


### PR DESCRIPTION
During a PR, contributor told me I don't need to add the year at the end of the name, however the doc said I did so I have now changed this.