### PR TITLE
Add Drupalcamp WI and Drupalcamp NYC 2016

### DIFF
--- a/data/events/drupalcamp-nyc-2016.json
+++ b/data/events/drupalcamp-nyc-2016.json
@@ -6,8 +6,8 @@
     "diversitytickets": "",
     "diversitytickets_text": "",
     "diversitytickets_url": "",
-    "event_end": "2016-07-08",
-    "event_start": "2016-07-11",
+    "event_end": "2016-07-11",
+    "event_start": "2016-07-08",
     "facebook": "https://www.facebook.com/NYCCamp/",
     "hashtag": "nyccamp",
     "languages": [

--- a/data/events/drupalcamp-nyc-2016.json
+++ b/data/events/drupalcamp-nyc-2016.json
@@ -16,7 +16,7 @@
     "location": {
         "city": "New York",
         "country": "USA",
-        "state": "New Your"
+        "state": "New York"
     },
     "name": "Drupal NYC Camp",
     "tags": ["drupal", "php", "web"],

--- a/data/events/drupalcamp-nyc-2016.json
+++ b/data/events/drupalcamp-nyc-2016.json
@@ -1,0 +1,26 @@
+{
+    "accessibility": "",
+    "cfp_end": "2016-05-31",
+    "code_of_conduct": "https://2016.nyccamp.org/code-of-conduct",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2016-07-08",
+    "event_start": "2016-07-11",
+    "facebook": "https://www.facebook.com/NYCCamp/",
+    "hashtag": "nyccamp",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "New York",
+        "country": "USA",
+        "state": "New Your"
+    },
+    "name": "Drupal NYC Camp",
+    "tags": ["drupal", "php", "web"],
+    "twitter": "drupalnyccamp",
+    "website": "https://2016.nyccamp.org/",
+    "youtube": ""
+}

--- a/data/events/drupalcamp-wi-2016.json
+++ b/data/events/drupalcamp-wi-2016.json
@@ -1,0 +1,26 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2016-07-29",
+    "event_start": "2016-07-29",
+    "facebook": "https://www.facebook.com/DrupalCampWI-182164998505289",
+    "hashtag": "dcwi",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Madison",
+        "country": "USA",
+        "state": "Wisconsin"
+    },
+    "name": "Drupal Camp WI",
+    "tags": ["drupal", "php", "web"],
+    "twitter": "drupalcampwi",
+    "website": "http://drupalcampwi.org/",
+    "youtube": ""
+}

--- a/missing_events.md
+++ b/missing_events.md
@@ -23,7 +23,6 @@
 
 * https://twitter.com/cocoaloveconf
 * https://twitter.com/voxxeddakar
-* https://twitter.com/drupalcampwi
 * https://twitter.com/gr8conf
 * https://twitter.com/lonestarruby
 * https://twitter.com/nordicapis


### PR DESCRIPTION
Please notice I did not remove drupalnyccamp from the missing_events.md file because dates of the 2017 event are still TBD.