### PR TITLE
Erase mistake in jsconf2015 event

### DIFF
--- a/data/events/jsconf-co-2015.json
+++ b/data/events/jsconf-co-2015.json
@@ -1,7 +1,7 @@
 {
     "accessibility": "",
     "cfp_end": "",
-    "code_of_conduct": "https://jsconf.co/2015-Videos/",
+    "code_of_conduct": "",
     "comment": "",
     "diversitytickets": "",
     "diversitytickets_text": "",


### PR DESCRIPTION
It was wrong link to code of conduct field, the right link for COC is broken. So i just deleted mistake.