### PR TITLE
A few updates to CoderCruise 2018

### DIFF
--- a/data/events/codercruise-2018.json
+++ b/data/events/codercruise-2018.json
@@ -14,7 +14,7 @@
         "country": "USA",
         "state": "Florida"
     },
-    "name": "CoderCruise 2018",
+    "name": "CoderCruise",
     "tags": [
         "javascript",
         "frontend",

--- a/data/events/codercruise-2018.json
+++ b/data/events/codercruise-2018.json
@@ -1,11 +1,11 @@
 {
     "accessibility": "",
-    "cfp_end": "",
+    "cfp_end": "2018-02-28",
     "code_of_conduct": "https://www.codercruise.com/code-of-conduct/",
     "diversitytickets": "",
     "event_end": "2018-09-03",
     "event_start": "2018-08-30",
-    "facebook": "https://www.facebook.com/events/208719319536607/",
+    "facebook": "",
     "languages": [
         "English"
     ],
@@ -14,7 +14,7 @@
         "country": "USA",
         "state": "Florida"
     },
-    "name": "CoderCruise",
+    "name": "CoderCruise 2018",
     "tags": [
         "javascript",
         "frontend",


### PR DESCRIPTION
Adding in the CfP end date, and removing the Facebook reference to last year's event.