### PR TITLE
Updated events & locations

### DIFF
--- a/data/events/devoxx-morocco-2016.json
+++ b/data/events/devoxx-morocco-2016.json
@@ -12,7 +12,7 @@
     ],
     "location": {
         "city": "Casablanca",
-        "country": "Morocoo",
+        "country": "Morocco",
         "state": ""
     },
     "name": "Devoxx Morocco",

--- a/data/events/devoxx-morocco-2017.json
+++ b/data/events/devoxx-morocco-2017.json
@@ -12,7 +12,7 @@
     ],
     "location": {
         "city": "Casablanca",
-        "country": "Morocoo",
+        "country": "Morocco",
         "state": ""
     },
     "name": "Devoxx Morocco",

--- a/data/events/wordcamp-harare-2018.json
+++ b/data/events/wordcamp-harare-2018.json
@@ -1,0 +1,28 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.harare.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-24",
+    "event_start": "2018-11-23",
+    "facebook": "https://www.facebook.com/wchre/",
+    "hashtag": "WCHRE",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Harare",
+        "country": "Zimbabwe",
+        "state": ""
+    },
+    "name": "WordCamp Harare",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "wordcampharare",
+    "website": "https://2018.harare.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-kampala-2018.json
+++ b/data/events/wordcamp-kampala-2018.json
@@ -1,0 +1,28 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.kampala.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-25",
+    "event_start": "2018-11-23",
+    "facebook": "",
+    "hashtag": "",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Kampala",
+        "country": "Uganda",
+        "state": ""
+    },
+    "name": "WordCamp Kampala",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "",
+    "website": "https://2018.kampala.wordcamp.org",
+    "youtube": ""
+}

--- a/data/events/wordcamp-kuala-lumpur-2018.json
+++ b/data/events/wordcamp-kuala-lumpur-2018.json
@@ -1,0 +1,28 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.kualalumpur.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-18",
+    "event_start": "2018-11-17",
+    "facebook": "",
+    "hashtag": "WCKL",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Kuala Lumpur",
+        "country": "Malaysia",
+        "state": ""
+    },
+    "name": "WordCamp Kuala Lumpur",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "WordCampKL",
+    "website": "https://2018.kualalumpur.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-montevideo-2018.json
+++ b/data/events/wordcamp-montevideo-2018.json
@@ -1,0 +1,28 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.montevideo.wordcamp.org/codigo-de-conducta/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-24",
+    "event_start": "2018-11-24",
+    "facebook": "https://www.facebook.com/WordPressUruguay",
+    "hashtag": "WCMVD",
+    "languages": [
+        "Spanish"
+    ],
+    "location": {
+        "city": "Montevideo",
+        "country": "Uruguay",
+        "state": ""
+    },
+    "name": "WordCamp Montevideo",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "montevideowp",
+    "website": "https://2018.montevideo.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-nairobi-2018.json
+++ b/data/events/wordcamp-nairobi-2018.json
@@ -1,0 +1,28 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.nairobi.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-24",
+    "event_start": "2018-11-23",
+    "facebook": "https://www.facebook.com/WordCampNairobi/",
+    "hashtag": "WordCampNairobi",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Nairobi",
+        "country": "Kenya",
+        "state": ""
+    },
+    "name": "WordCamp Nairobi",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "wordcampnairobi",
+    "website": "https://2018.nairobi.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-pokhara-2018.json
+++ b/data/events/wordcamp-pokhara-2018.json
@@ -1,0 +1,33 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.pokhara.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-24",
+    "event_start": "2018-11-24",
+    "facebook": "https://www.facebook.com/WordCampPokhara/",
+    "hashtag": "WCPKR2018",
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Pokhara",
+        "country": "Nepal",
+        "state": ""
+    },
+    "name": "WordCamp Nepal",
+    "tags": [
+        "wordpress",
+        "ux",
+        "ui",
+        "design",
+        "aws"
+
+    ],
+    "twitter": "wppokhara",
+    "website": "https://2018.pokhara.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-sofia-2018.json
+++ b/data/events/wordcamp-sofia-2018.json
@@ -1,0 +1,35 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": [
+        "https://2018.sofia.wordcamp.org/etichen-kodeks/",
+        "https://2018.sofia.wordcamp.org/code-of-conduct/"
+    ],
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-11-25",
+    "event_start": "2018-11-24",
+    "facebook": "https://www.facebook.com/wordcampbg",
+    "hashtag": "WCSOF",
+    "languages": [
+        "English",
+        "Bulgarian"
+    ],
+    "location": {
+        "city": "Sofia",
+        "country": "Bulgaria",
+        "state": ""
+    },
+    "name": "WordCamp Bulgaria",
+    "tags": [
+        "agile",
+        "wordpress",
+        "ux",
+        "api"
+    ],
+    "twitter": "wordcampsofia",
+    "website": "https://2018.sofia.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/events/wordcamp-toronto-2018.json
+++ b/data/events/wordcamp-toronto-2018.json
@@ -1,0 +1,31 @@
+{
+    "accessibility": "",
+    "cfp_end": "",
+    "code_of_conduct": "https://2018.toronto.wordcamp.org/code-of-conduct/",
+    "comment": "",
+    "diversitytickets": "",
+    "diversitytickets_text": "",
+    "diversitytickets_url": "",
+    "event_end": "2018-12-01",
+    "event_start": "2018-12-01",
+    "facebook": "https://www.facebook.com/WCYYZ/",
+    "hashtag": [
+         "WCYYZ",
+         "WCYYZ18"
+    ],
+    "languages": [
+        "English"
+    ],
+    "location": {
+        "city": "Toronto",
+        "country": "USA",
+        "state": "Ontario"
+    },
+    "name": "WordCamp Toronto",
+    "tags": [
+        "wordpress"
+    ],
+    "twitter": "wcyyz",
+    "website": "https://2018.toronto.wordcamp.org/",
+    "youtube": ""
+}

--- a/data/locations.json
+++ b/data/locations.json
@@ -547,6 +547,12 @@
             "Europe": "1"
         }
     },
+    "Uganda": {
+        "Kampala": "1",
+        "_area_": {
+            "Africa": "1"
+        }
+    },
     "UK": {
         "England": {
             "Birmingham": "1",

--- a/data/locations.json
+++ b/data/locations.json
@@ -378,6 +378,12 @@
             "Africa": "1"
         }
     },
+    "Nepal": {
+        "Pokhara": "1",
+        "_area_": {
+            "Asia": "1"
+        }
+    },
     "New Zealand": {
         "Auckland": "1",
         "Wellington": "1",

--- a/data/locations.json
+++ b/data/locations.json
@@ -372,7 +372,7 @@
             "North America": "1"
         }
     },
-    "Morocoo": {
+    "Morocco": {
         "Casablanca": "1",
         "_area_": {
             "Africa": "1"


### PR DESCRIPTION
Added data/events:
- WordCamp Kuala Lumpur 2018 event
- WordCamp Harare 2018 event
- WordCamp Kampala 2018 event
- WordCamp Nairobi 2018 event
- WordCamp Pokhara 2018 event
- WordCamp Sofia 2018 event - please, check "code of conduct" property (event's site is bilingual), there are 2 values and I'm not quite sure if I added it correctly
- WordCamp Montevideo 2018 event
- WordCamp Toronto 2018 event - please, check "hashtag" property, there are 2 values (they have 2 hashtags) and I'm not quite sure if I added it correctly.

Added locations:
- Uganda/Kampala
- Nepal/Pokhara

Fixed:
- A typo in locations: Morocoo -> Morocco
- Typos in data/events: Devoxx Morocco 2016 & Devoxx Morocco 2017