### PR TITLE
Fix Ben Patterson info.

### DIFF
--- a/data/people/ben-patterson.json
+++ b/data/people/ben-patterson.json
@@ -1,6 +1,6 @@
 {
-    "country": "Parker, CO, USA",
-    "home": "http://www.bentheredothat.com/",
+    "country": "Boston, MA, USA",
+    "home": "https://www.fifteenlinesoffame.com/",
     "name": "Ben Patterson",
-    "twitter": "BenInIowa"
+    "twitter": "benmadrone"
 }


### PR DESCRIPTION
Example is the Jenkins World 2016 talk on "Using Jenkins for Diverse Feedback
on GitHub." There are many Ben Pattersons, but this is the one from
Massachusetts.

@szabgab hey I saw this error and wanted to correct it...