### PR TITLE
make navbar sticky, add box shadow

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -200,8 +200,14 @@ li {
 nav {
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    /* overflow: hidden; */
     background-color: #333;
+    box-shadow: 0 2px 10px 0 rgba(0,0,0,0.15);
+    position: -webkit-sticky;  /* for Safari */
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 1;
 }
 
 nav ul {


### PR DESCRIPTION
Navigation menu bar sticks to the top when page scrolls.
I did NOT know how to run local test in Safari (I'm on Windows). If for that reason or for aesthetic/other reasons this change is a no-go, I won't be offended!